### PR TITLE
Fix gallery link

### DIFF
--- a/ChunkyDocs/docs/theme_override/home.html
+++ b/ChunkyDocs/docs/theme_override/home.html
@@ -182,7 +182,7 @@
         >
           Download Chunky
         </a>
-        <a href="/docs/gallery/gallery" class="md-button"> Visit Gallery </a>
+        <a href="/docs/gallery" class="md-button"> Visit Gallery </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I noticed the gallery link points to the wrong URL (https://chunky-dev.github.io/docs/gallery/gallery) which gives a 404 error. The correct link seems to be https://chunky-dev.github.io/docs/gallery